### PR TITLE
Eliminate the need to use "-h 127.0.0.1:6631" in lp* commands (lpadmin, lpstat, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a series of sample YAML files that stand up a CUPS print server running 
 ## Deployment
 To deploy this example directly to your OpenShift or Kubernetes cluster do:
 ```
-$ kubectl create -f namespace.yaml -f cups-conf.yaml -f cups-files.yaml -f pod.yaml -f service.yaml
+$ kubectl create -f namespace.yaml -f cups-conf.yaml -f cups-files.yaml -f client-conf.yaml -f pod.yaml -f service.yaml
 ```
 
 ## Teardown

--- a/client-conf.yaml
+++ b/client-conf.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: client-conf
+  namespace: cups
+  labels:
+    app: cups
+data:
+  client.conf: |
+    ServerName 127.0.0.1:6631

--- a/pod.yaml
+++ b/pod.yaml
@@ -20,6 +20,9 @@ spec:
     - name: cups-files
       mountPath: /etc/cups/cups-files.conf
       subPath: cups-files.conf
+    - name: client-conf
+      mountPath: /etc/cups/client.conf
+      subPath: client.conf
     imagePullPolicy: Always
   volumes:
   - name: cups-config
@@ -28,3 +31,6 @@ spec:
   - name: cups-files
     configMap:
       name: cups-files
+  - name: client-conf
+    configMap:
+      name: client-conf


### PR DESCRIPTION
This is an attempt to add the file /etc/cups/client.conf to the image and fill it with:

    ServerName 127.0.0.1:6631

So that you won't need to add "-h 127.0.0.1:6631 to all of the CUPS lp* commands.  I created it by copying portions of the other .yaml files, but my knowledge of Docker/OpenShift is minimal, so there's likely to be errors, but I thought it would give you an idea of what could be done.